### PR TITLE
refactor: replace prints with logging in crossmatching scripts

### DIFF
--- a/crossmatching/toa_crossmatch.py
+++ b/crossmatching/toa_crossmatch.py
@@ -4,6 +4,10 @@ from astropy.time import Time
 from astropy.coordinates import SkyCoord, EarthLocation
 import astropy.constants as const
 
+from flits.common.logging import get_logger
+
+logger = get_logger(__name__)
+
 # Assume these are defined elsewhere in your script
 # from baseband_analysis.core.bbdata import BBData
 # from baseband_analysis.core.dedispersion import delay_across_the_band
@@ -44,7 +48,7 @@ dsa_mjd = 59000.1
 chime_unix_timestamp = 1598882400.0 # Example Unix time
 source_coord = "12:00:00 +20:00:00"
 
-print("--- Analyzing Single Burst ---")
+logger.info("--- Analyzing Single Burst ---")
 
 # ==================================================================
 # This section would contain your CHIME data processing code
@@ -86,7 +90,7 @@ shift_400_dsa = K_DM * DM.value * (1/F_REF.value**2 - 1/f_center_dsa.value**2) *
 toa_400_utc_dsa = t_peak_utc_dsa + shift_400_dsa
 
 # --- UNCERTAINTY CALCULATION ---
-print(f"Assumed DM Uncertainty: {dm_uncertainty:.2f} pc/cm^3")
+logger.info("Assumed DM Uncertainty: %.2f pc/cm^3", dm_uncertainty)
 
 # Calculate timing error for each observatory relative to the 400 MHz reference
 error_chime = calculate_dm_timing_error(dm_uncertainty, f_center_chime, F_REF)
@@ -95,13 +99,13 @@ error_dsa = calculate_dm_timing_error(dm_uncertainty, f_center_dsa, F_REF)
 # The total uncertainty on the offset is the sum in quadrature
 delta_t_uncertainty = np.sqrt(error_chime**2 + error_dsa**2)
 
-print(f"CHIME TOA Error due to DM uncertainty: {error_chime:.3f}")
-print(f"DSA-110 TOA Error due to DM uncertainty: {error_dsa:.3f}")
+logger.info("CHIME TOA Error due to DM uncertainty: %s", error_chime)
+logger.info("DSA-110 TOA Error due to DM uncertainty: %s", error_dsa)
 
 # --- Final Results ---
 dt = toa_400_utc_chime - toa_400_utc_dsa
-print(f"\nMeasured TOA Offset (Δt): {dt.to(u.ms):.3f}")
-print(f"Combined Uncertainty on Δt from DM: ±{delta_t_uncertainty:.3f}")
+logger.info("\nMeasured TOA Offset (Δt): %s", dt.to(u.ms))
+logger.info("Combined Uncertainty on Δt from DM: ±%s", delta_t_uncertainty)
 
 # Geometric delay calculation
 src = SkyCoord(source_coord, unit=(u.hourangle, u.deg), frame='icrs')
@@ -114,4 +118,4 @@ def geometric_delay(t):
     proj = (p2 - p1).dot(src.cartesian.xyz)
     return (proj / const.c).to(u.ms)
 
-print(f"Geometric Delay: {geometric_delay(toa_400_utc_chime):.3f}")
+logger.info("Geometric Delay: %s", geometric_delay(toa_400_utc_chime))

--- a/flits/__init__.py
+++ b/flits/__init__.py
@@ -1,0 +1,5 @@
+"""FLITS package initialization."""
+
+from .common.logging import get_logger
+
+__all__ = ["get_logger"]

--- a/flits/common/__init__.py
+++ b/flits/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities for FLITS."""

--- a/flits/common/logging.py
+++ b/flits/common/logging.py
@@ -1,0 +1,17 @@
+import logging
+from typing import Optional
+
+DEFAULT_LOG_LEVEL = logging.INFO
+LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger configured for the FLITS project.
+
+    Parameters
+    ----------
+    name : str, optional
+        Name of the logger to retrieve. Defaults to the root package name.
+    """
+    if not logging.getLogger().handlers:
+        logging.basicConfig(level=DEFAULT_LOG_LEVEL, format=LOG_FORMAT)
+    return logging.getLogger(name if name else "flits")


### PR DESCRIPTION
## Summary
- add shared logging helper
- switch crossmatching scripts to use logging instead of print statements

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'manim'; ImportError: cannot import name 'get_dm')*
- `pip install manim` *(fails: RequiredDependencyException: pangocairo >= 1.30.0 is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b825e53bf88330a23cac3fb9b5aef9