### PR TITLE
Add FRB modeling modules with sampler and tests

### DIFF
--- a/flits/__init__.py
+++ b/flits/__init__.py
@@ -7,7 +7,6 @@ __all__ = [
     "FRBModel",
     "FRBParams",
     "FRBFitter",
-    "_log_prob_wrapper",
     "plot_time_series",
     "plot_model",
 ]

--- a/flits/__init__.py
+++ b/flits/__init__.py
@@ -1,0 +1,13 @@
+from .models import FRBModel
+from .params import FRBParams
+from .sampler import FRBFitter, _log_prob_wrapper
+from .plotting import plot_time_series, plot_model
+
+__all__ = [
+    "FRBModel",
+    "FRBParams",
+    "FRBFitter",
+    "_log_prob_wrapper",
+    "plot_time_series",
+    "plot_model",
+]

--- a/flits/models.py
+++ b/flits/models.py
@@ -1,0 +1,48 @@
+"""Simple FRB signal model utilities."""
+from __future__ import annotations
+
+import numpy as np
+
+from .params import FRBParams
+
+# Dispersion constant (ms MHz^2 pc^-1 cm^3)
+K_DM = 4.148808e3
+
+
+class FRBModel:
+    """Generates dispersed Gaussian pulses."""
+
+    def __init__(self, params: FRBParams):
+        self.params = params
+
+    def simulate(self, t: np.ndarray, freqs: np.ndarray) -> np.ndarray:
+        """Return model intensity for times ``t`` and frequencies ``freqs``.
+
+        Parameters
+        ----------
+        t : array-like
+            Time axis in milliseconds.
+        freqs : array-like
+            Frequencies in MHz.
+
+        Returns
+        -------
+        np.ndarray
+            Array with shape (len(freqs), len(t)) representing a dynamic
+            spectrum where each row corresponds to one frequency channel.
+        """
+        t = np.asarray(t)
+        freqs = np.asarray(freqs)
+
+        delays = K_DM * self.params.dm / freqs**2  # ms
+        result = []
+        for delay in delays:
+            shifted = t - (self.params.t0 + delay)
+            pulse = self.params.amplitude * np.exp(
+                -0.5 * (shifted / self.params.width) ** 2
+            )
+            result.append(pulse)
+        return np.vstack(result)
+
+
+__all__ = ["FRBModel", "K_DM"]

--- a/flits/params.py
+++ b/flits/params.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class FRBParams:
+    """Parameters describing a simple fast radio burst model."""
+
+    dm: float  # Dispersion measure in pc cm^-3
+    amplitude: float  # Pulse amplitude in arbitrary units
+    t0: float = 0.0  # Reference arrival time in ms
+    width: float = 1.0  # Gaussian width of the burst in ms
+
+
+__all__ = ["FRBParams"]

--- a/flits/plotting.py
+++ b/flits/plotting.py
@@ -1,0 +1,31 @@
+"""Plotting helpers for FRB simulations."""
+from __future__ import annotations
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from .models import FRBModel
+from .params import FRBParams
+
+
+def plot_time_series(t: np.ndarray, data: np.ndarray, ax: plt.Axes | None = None) -> plt.Axes:
+    """Plot a simple time series."""
+    if ax is None:
+        _, ax = plt.subplots()
+    ax.plot(t, data)
+    ax.set_xlabel("Time [ms]")
+    ax.set_ylabel("Intensity [arb]")
+    return ax
+
+
+def plot_model(
+    t: np.ndarray, freqs: np.ndarray, params: FRBParams, ax: plt.Axes | None = None
+) -> plt.Axes:
+    """Plot the average model time series over all frequencies."""
+    model = FRBModel(params)
+    spec = model.simulate(t, freqs)
+    avg = spec.mean(axis=0)
+    return plot_time_series(t, avg, ax=ax)
+
+
+__all__ = ["plot_time_series", "plot_model"]

--- a/flits/sampler.py
+++ b/flits/sampler.py
@@ -1,0 +1,74 @@
+"""Sampling utilities for FRB models."""
+from __future__ import annotations
+
+import numpy as np
+import emcee
+
+from .models import FRBModel
+from .params import FRBParams
+
+
+
+def _log_prob_wrapper(
+    theta: np.ndarray,
+    t: np.ndarray,
+    freqs: np.ndarray,
+    data: np.ndarray,
+    noise_std: float,
+    t0: float = 0.0,
+    width: float = 1.0,
+) -> float:
+    """Log-probability for sampling FRB parameters.
+
+    This function combines a simple Gaussian likelihood with uniform priors on
+    ``dm`` and ``amplitude`` (both must be positive).
+    """
+    dm, amp = theta
+    if dm < 0 or amp < 0 or width <= 0:
+        return -np.inf
+
+    params = FRBParams(dm=dm, amplitude=amp, t0=t0, width=width)
+    model = FRBModel(params)
+    model_spec = model.simulate(t, freqs)
+    resid = data - model_spec
+    return -0.5 * np.sum((resid / noise_std) ** 2)
+
+
+class FRBFitter:
+    """Fit :class:`FRBModel` parameters using ``emcee`` MCMC."""
+
+    def __init__(
+        self,
+        t: np.ndarray,
+        freqs: np.ndarray,
+        data: np.ndarray,
+        noise_std: float = 1.0,
+    ) -> None:
+        self.t = np.asarray(t)
+        self.freqs = np.asarray(freqs)
+        self.data = np.asarray(data)
+        self.noise_std = float(noise_std)
+        self.sampler: emcee.EnsembleSampler | None = None
+
+    def sample(
+        self,
+        initial: np.ndarray,
+        nwalkers: int = 32,
+        nsteps: int = 100,
+        **kwargs,
+    ) -> emcee.EnsembleSampler:
+        """Run the MCMC sampler and return the ``emcee`` sampler instance."""
+        ndim = len(initial)
+        p0 = initial + 1e-4 * np.random.randn(nwalkers, ndim)
+        sampler = emcee.EnsembleSampler(
+            nwalkers,
+            ndim,
+            _log_prob_wrapper,
+            args=(self.t, self.freqs, self.data, self.noise_std),
+        )
+        sampler.run_mcmc(p0, nsteps, progress=False, **kwargs)
+        self.sampler = sampler
+        return sampler
+
+
+__all__ = ["FRBFitter", "_log_prob_wrapper"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,10 +1,4 @@
-import sys
-import pathlib
 import numpy as np
-
-# Ensure package root is on the path
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-
 from flits.params import FRBParams
 from flits.models import FRBModel, K_DM
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,31 @@
+import sys
+import pathlib
+import numpy as np
+
+# Ensure package root is on the path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from flits.params import FRBParams
+from flits.models import FRBModel, K_DM
+
+
+def test_frbmodel_peak_time_no_dm():
+    t = np.linspace(0, 10, 1001)
+    freqs = np.array([1000.0])
+    params = FRBParams(dm=0.0, amplitude=1.0, t0=5.0, width=0.5)
+    model = FRBModel(params)
+    spec = model.simulate(t, freqs)
+    peak_time = t[np.argmax(spec[0])]
+    assert abs(peak_time - 5.0) < 1e-3
+
+
+def test_frbmodel_dispersion_delay():
+    t = np.linspace(0, 10, 2001)
+    freqs = np.array([1000.0, 800.0])
+    params = FRBParams(dm=50.0, amplitude=1.0, t0=0.0, width=0.2)
+    model = FRBModel(params)
+    spec = model.simulate(t, freqs)
+    peak_high = t[np.argmax(spec[0])]
+    peak_low = t[np.argmax(spec[1])]
+    expected_delay = K_DM * params.dm * (1 / freqs[1] ** 2 - 1 / freqs[0] ** 2)
+    assert np.isclose(peak_low - peak_high, expected_delay, atol=1e-2)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,30 @@
+import sys
+import pathlib
+import numpy as np
+
+# Ensure package root is on the path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from flits.params import FRBParams
+from flits.models import FRBModel
+from flits.sampler import FRBFitter, _log_prob_wrapper
+
+
+def test_fitter_improves_log_prob():
+    np.random.seed(0)
+    t = np.linspace(-5, 5, 512)
+    freqs = np.array([800.0, 400.0])
+    true_params = FRBParams(dm=100.0, amplitude=1.0, t0=0.0, width=0.5)
+    model = FRBModel(true_params)
+    spec = model.simulate(t, freqs)
+    noise_std = 0.05
+    data = spec + np.random.normal(0, noise_std, size=spec.shape)
+
+    fitter = FRBFitter(t, freqs, data, noise_std)
+    initial = np.array([80.0, 0.5])
+    initial_lp = _log_prob_wrapper(initial, t, freqs, data, noise_std)
+    sampler = fitter.sample(initial, nwalkers=8, nsteps=40)
+    final_lp = sampler.get_log_prob(flat=True)[-1]
+    assert final_lp > initial_lp
+    chain = sampler.get_chain()
+    assert chain.shape == (40, 8, 2)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -2,9 +2,6 @@ import sys
 import pathlib
 import numpy as np
 
-# Ensure package root is on the path
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-
 from flits.params import FRBParams
 from flits.models import FRBModel
 from flits.sampler import FRBFitter, _log_prob_wrapper


### PR DESCRIPTION
## Summary
- Add FRBParams dataclass and FRBModel for simulating dispersed Gaussian pulses
- Introduce MCMC-based FRBFitter with log-probability wrapper
- Provide plotting helpers and unit tests for model and sampler

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b825e3fd98833098dd98d1ba75ac6d