### PR TITLE
Add dataclass-based configuration loader

### DIFF
--- a/scattering/scat_analysis/config_utils.py
+++ b/scattering/scat_analysis/config_utils.py
@@ -8,17 +8,74 @@ Utility for reading telescope-specific raw-data parameters from
 """
 
 from __future__ import annotations
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict
-import yaml
+from typing import Any, Dict, Optional
+
 import functools
+import yaml
 
 __all__ = [
+    "TelescopeConfig",
+    "SamplerConfig",
+    "PipelineOptions",
+    "Config",
     "load_telescope_block",
     "load_sampler_block",
     "load_sampler_choice",
+    "load_config",
     "clear_config_cache",
 ]
+
+
+@dataclass
+class TelescopeConfig:
+    """Container for raw telescope parameters."""
+    name: str
+    df_MHz_raw: float
+    dt_ms_raw: float
+    f_min_GHz: float
+    f_max_GHz: float
+    n_ch_raw: Optional[int] = None
+
+
+@dataclass
+class SamplerConfig:
+    """Container for sampler settings.  Arbitrary keys are stored in ``params``."""
+    name: str
+    params: Dict[str, Any] = field(default_factory=dict)
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - simple delegation
+        try:
+            return self.params[item]
+        except KeyError as exc:  # pragma: no cover - error path
+            raise AttributeError(f"Sampler setting '{item}' not found") from exc
+
+
+@dataclass
+class PipelineOptions:
+    """General options controlling the BurstFit pipeline."""
+    steps: int = 2000
+    f_factor: int = 1
+    t_factor: int = 1
+    nproc: Optional[int] = None
+    extend_chain: bool = False
+    chunk_size: int = 0
+    max_chunks: int = 0
+    model_scan: bool = True
+    diagnostics: bool = True
+    plot: bool = True
+
+
+@dataclass
+class Config:
+    """Top-level configuration object returned by :func:`load_config`."""
+    path: Path
+    dm_init: float
+    telescope: TelescopeConfig
+    sampler: SamplerConfig
+    pipeline: PipelineOptions
+
 
 @functools.lru_cache(maxsize=None)
 def _read_yaml(path: str | Path) -> dict:
@@ -26,28 +83,16 @@ def _read_yaml(path: str | Path) -> dict:
     with Path(path).expanduser().open("r", encoding="utf-8") as fh:
         return yaml.safe_load(fh) or {}
 
+
 def load_telescope_block(
     telcfg_path: str | Path = "telescopes.yaml",
     telescope: str | None = None,
-) -> tuple[str, dict]:
-    """
-    Return ``(name, params)`` for the requested telescope.
+) -> TelescopeConfig:
+    """Return a :class:`TelescopeConfig` for the requested telescope."""
 
-    Parameters
-    ----------
-    telcfg_path
-        Path to the YAML file that contains a ``telescopes:`` section.
-    telescope
-        Which telescope to load.  If *None*, use ``default_telescope`` from
-        the YAML file, falling back to the *first* telescope encountered.
-
-    The function validates and converts the four required fields::
-
-        df_MHz_raw, dt_ms_raw, f_min_GHz, f_max_GHz
-    """
     cfg = _read_yaml(telcfg_path)
 
-    blocks = cfg.get("telescopes", cfg)   # legacy files may be flat
+    blocks = cfg.get("telescopes", cfg)  # legacy files may be flat
     if not isinstance(blocks, dict) or not blocks:
         raise KeyError(f"No 'telescopes' block found in {telcfg_path}")
 
@@ -62,41 +107,90 @@ def load_telescope_block(
 
     entry = blocks[telescope]
     required = ("df_MHz_raw", "dt_ms_raw", "f_min_GHz", "f_max_GHz")
-    missing  = [k for k in required if k not in entry or entry[k] is None]
+    missing = [k for k in required if k not in entry or entry[k] is None]
     if missing:
         raise ValueError(
-            f"Telescope '{telescope}' in '{telcfg_path}' "
-            f"is missing fields {missing}"
+            f"Telescope '{telescope}' in '{telcfg_path}' is missing fields {missing}"
         )
 
     params = {k: float(entry[k]) for k in required}
-    return telescope, params
+    if "n_ch_raw" in entry and entry["n_ch_raw"] is not None:
+        params["n_ch_raw"] = int(entry["n_ch_raw"])
 
-def load_sampler_block(path: str | Path = "sampler.yaml",
-                       name: str | None = None) -> tuple[str, dict]:
-    """
-    Return ``(sampler_name, params_dict)``.
+    return TelescopeConfig(name=telescope, **params)
 
-    * If *name* is given, use that sampler.
-    * Otherwise use ``default_sampler`` from YAML (falls back to 'emcee').
-    """
+
+def load_sampler_block(
+    path: str | Path = "sampler.yaml", name: str | None = None
+) -> SamplerConfig:
+    """Return a :class:`SamplerConfig` representing the chosen sampler."""
+
     cfg = _read_yaml(path)
 
     samplers = cfg.get("samplers", {})
     if not samplers:
         raise KeyError("No 'samplers' section found in sampler YAML")
 
-    # decide which block we want
     target = (name or cfg.get("default_sampler") or "emcee").lower()
     if target not in samplers:
-        raise KeyError(f"Sampler '{target}' not found in YAML. "
-                       f"Available: {list(samplers)}")
+        raise KeyError(
+            f"Sampler '{target}' not found in YAML. Available: {list(samplers)}"
+        )
 
-    return target, samplers[target]
+    return SamplerConfig(name=target, params=samplers[target])
+
 
 def load_sampler_choice(path: str | Path = "sampler.yaml") -> str:
     """Return only the default sampler name (helper for CLI autocompletion)."""
-    return load_sampler_block(path)[0]
+    return load_sampler_block(path).name
+
+
+def load_config(path: str | Path) -> Config:
+    """Load the full analysis configuration from ``path``.
+
+    The file specified by *path* is expected to contain run-specific options
+    such as the data ``path``, ``dm_init`` and ``telescope`` choice.  The
+    corresponding ``telescopes.yaml`` and ``sampler.yaml`` files are assumed to
+    live in the same directory unless explicit ``telcfg_path`` or
+    ``sampcfg_path`` entries are provided.
+    """
+
+    run_path = Path(path).expanduser()
+    with run_path.open("r", encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh) or {}
+
+    base_dir = run_path.parent
+    telcfg_path = cfg.get("telcfg_path", base_dir / "telescopes.yaml")
+    sampcfg_path = cfg.get("sampcfg_path", base_dir / "sampler.yaml")
+
+    if "telescope" not in cfg:
+        raise ValueError("Run config is missing required field 'telescope'")
+
+    telescope = load_telescope_block(telcfg_path, cfg["telescope"])
+    sampler = load_sampler_block(sampcfg_path, cfg.get("sampler"))
+
+    data_path = cfg.get("path")
+    if data_path is None:
+        raise ValueError("Run config must specify 'path' to the data file")
+
+    dm_init = float(cfg.get("dm_init", 0.0))
+
+    pipe = PipelineOptions(
+        steps=int(cfg.get("steps", 2000)),
+        f_factor=int(cfg.get("f_factor", 1)),
+        t_factor=int(cfg.get("t_factor", 1)),
+        nproc=cfg.get("nproc"),
+        extend_chain=bool(cfg.get("extend_chain", False)),
+        chunk_size=int(cfg.get("chunk_size", 0)),
+        max_chunks=int(cfg.get("max_chunks", 0)),
+        model_scan=bool(cfg.get("model_scan", True)),
+        diagnostics=bool(cfg.get("diagnostics", True)),
+        plot=bool(cfg.get("plot", True)),
+    )
+
+    return Config(path=Path(data_path), dm_init=dm_init,
+                  telescope=telescope, sampler=sampler, pipeline=pipe)
+
 
 def clear_config_cache() -> None:
     """Clear the in-memory YAML cache for telescope & sampler loaders."""

--- a/scattering/scat_analysis/config_utils.py
+++ b/scattering/scat_analysis/config_utils.py
@@ -188,8 +188,13 @@ def load_config(path: str | Path) -> Config:
         plot=bool(cfg.get("plot", True)),
     )
 
-    return Config(path=Path(data_path), dm_init=dm_init,
-                  telescope=telescope, sampler=sampler, pipeline=pipe)
+    return Config(
+        path=Path(data_path),
+        dm_init=dm_init,
+        telescope=telescope,
+        sampler=sampler,
+        pipeline=pipe,
+    )
 
 
 def clear_config_cache() -> None:

--- a/scattering/scat_analysis/old_code/burstfit_pipeline_v0.py
+++ b/scattering/scat_analysis/old_code/burstfit_pipeline_v0.py
@@ -314,8 +314,10 @@ class BurstDataset:
         lazy: bool = False,
     ) -> None:
         self.path = Path(path)
-        self.telname, self.telparams = load_telescope_block(telcfg_path, telescope=telescope)
-        self.sampname, self.sampparams = load_sampler_block(sampcfg_path)
+        self.telparams = load_telescope_block(telcfg_path, telescope=telescope)
+        self.telname = self.telparams.name
+        self.sampparams = load_sampler_block(sampcfg_path)
+        self.sampname = self.sampparams.name
         assert 0.0 <= outer_trim < 0.5, "outer_trim must be < 0.5"
         self.f_factor = f_factor
         self.t_factor = t_factor
@@ -487,9 +489,9 @@ class BurstDataset:
 
     def _build_axes(self, ds):
         p = self.telparams
-        self.df_MHz = p["df_MHz_raw"] * self.f_factor
-        self.dt_ms = p["dt_ms_raw"] * self.t_factor
-        freq = np.linspace(p["f_min_GHz"], p["f_max_GHz"], ds.shape[0])
+        self.df_MHz = p.df_MHz_raw * self.f_factor
+        self.dt_ms = p.dt_ms_raw * self.t_factor
+        freq = np.linspace(p.f_min_GHz, p.f_max_GHz, ds.shape[0])
         time = np.arange(ds.shape[1]) * self.dt_ms
         return freq, time
 

--- a/scattering/scat_analysis/old_code/burstfit_pipeline_v1.py
+++ b/scattering/scat_analysis/old_code/burstfit_pipeline_v1.py
@@ -260,8 +260,10 @@ class BurstDataset:
         lazy: bool = False,
     ):
         self.path = Path(path)
-        self.telname, self.telparams = load_telescope_block(telcfg_path, telescope=telescope)
-        self.sampname, self.sampparams = load_sampler_block(sampcfg_path)
+        self.telparams = load_telescope_block(telcfg_path, telescope=telescope)
+        self.telname = self.telparams.name
+        self.sampparams = load_sampler_block(sampcfg_path)
+        self.sampname = self.sampparams.name
         self.f_factor, self.t_factor = f_factor, t_factor
         self.outer_trim, self.smooth_ms = outer_trim, smooth_ms
         self.center_burst, self.flip_freq = center_burst, flip_freq
@@ -299,11 +301,11 @@ class BurstDataset:
     def _build_axes(self, shape):
         n_ch_raw, n_t_raw = shape
         p = self.telparams
-        df_MHz = p["df_MHz_raw"] * self.f_factor
-        dt_ms = p["dt_ms_raw"] * self.t_factor
+        df_MHz = p.df_MHz_raw * self.f_factor
+        dt_ms = p.dt_ms_raw * self.t_factor
         final_n_ch = n_ch_raw // self.f_factor
         final_n_t = n_t_raw // self.t_factor
-        freq = np.linspace(p["f_min_GHz"], p["f_max_GHz"], final_n_ch)
+        freq = np.linspace(p.f_min_GHz, p.f_max_GHz, final_n_ch)
         time = np.arange(final_n_t) * dt_ms
         return freq, time, df_MHz, dt_ms
 


### PR DESCRIPTION
## Summary
- Introduce `TelescopeConfig`, `SamplerConfig`, and `PipelineOptions` dataclasses
- Replace dictionary-style access in BurstFit dataset and scripts with attribute access
- Provide a unified `load_config` entrypoint for scattering pipeline

## Testing
- `pytest` *(fails: No module named 'manim'; ImportError: cannot import name 'get_dm')*
- `python -m py_compile scattering/scat_analysis/config_utils.py scattering/scat_analysis/burstfit_pipeline.py scattering/run_scat_analysis.py scattering/scat_analysis/old_code/burstfit_pipeline_v0.py scattering/scat_analysis/old_code/burstfit_pipeline_v1.py`


------
https://chatgpt.com/codex/tasks/task_e_68b825bb503c8330a32cfd01416b5479